### PR TITLE
remove usertoken

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "token": "ODYwOTc2Mjk3ODkwODA3ODM4.YODEqQ.mzP94NWAndWzhH-KHXzx-18AJEU",
+    "token": "<token goes here>",
     "prefix": "!g",
     "everyoneMention": false,
     "hostedBy": true


### PR DESCRIPTION
Hey there @liammondiscord! In future you shouldn’t commit your bot token, though GitHub has a secret-scanner (token scanning) tool which invalidated your Discord bot token when you pushed the commit (or commited it on the web editor). You probably received a system message on Discord because of this too. Anyways, this pull request just removes the invalidated token, and I hope this message is of use to you.
Take care!